### PR TITLE
fix: improve UI consistency and navigation in History and Settings pages

### DIFF
--- a/src/components/DigDeeperModal.tsx
+++ b/src/components/DigDeeperModal.tsx
@@ -475,39 +475,38 @@ const DigDeeperModal: React.FC<DigDeeperModalProps> = ({ isOpen, onClose, post }
                   {conversationStage}
                 </span>
               )}
+              <a
+                href={post.permalink}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  background: '#D93801',
+                  color: 'white',
+                  padding: '0.25rem 0.5rem',
+                  borderRadius: '0.25rem',
+                  textDecoration: 'none',
+                  fontWeight: '500',
+                  fontSize: '0.75rem',
+                  transition: 'background-color 0.2s'
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor = '#B8310A';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = '#D93801';
+                }}
+              >
+                Join conversation on Reddit
+                <ExternalLink style={{width: '0.75rem', height: '0.75rem', marginLeft: '0.375rem'}} />
+              </a>
               {isResumedConversation && (
                 <span className="dig-deeper-modal-resumed">
                   Resumed
                 </span>
               )}
             </div>
-            <a
-              href={post.permalink}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                background: '#D93801',
-                color: 'white',
-                padding: '0.5rem 1rem',
-                borderRadius: '0.375rem',
-                textDecoration: 'none',
-                fontWeight: '500',
-                fontSize: '0.75rem',
-                marginTop: '0.75rem',
-                transition: 'background-color 0.2s'
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.backgroundColor = '#B8310A';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.backgroundColor = '#D93801';
-              }}
-            >
-              Join conversation on Reddit
-              <ExternalLink style={{width: '0.75rem', height: '0.75rem', marginLeft: '0.375rem'}} />
-            </a>
           </div>
         </div>
 

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -116,7 +116,7 @@ const HistoryPage: React.FC = () => {
           <Search style={{width: '4rem', height: '4rem', color: '#9ca3af'}} />
           <h3>No Analysis History</h3>
           <p>Your completed analyses will appear here</p>
-          <a href="/" className="apollo-btn-primary">
+          <a href="/app" className="apollo-btn-primary">
             Run Your First Analysis
           </a>
         </div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Settings, Save, RotateCcw } from 'lucide-react';
+import { Settings, Save, RotateCcw, AlertTriangle } from 'lucide-react';
 
 interface SettingsState {
   theme: 'light' | 'dark';
@@ -21,6 +21,7 @@ const SettingsPage: React.FC = () => {
   });
 
   const [saved, setSaved] = useState(false);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
 
   useEffect(() => {
     // Load settings from localStorage
@@ -68,11 +69,39 @@ const SettingsPage: React.FC = () => {
     setSettings(prev => ({ ...prev, [key]: value }));
   };
 
+  /**
+   * Show confirmation modal for clearing all data
+   * Why this matters: Provides a custom modal experience instead of browser popup for better UX
+   */
+  const showClearConfirmation = () => {
+    setShowConfirmModal(true);
+  };
+
+  /**
+   * Clear all data after confirmation
+   * Why this matters: Performs the actual deletion of all data after user confirms
+   */
+  const confirmClearData = () => {
+    localStorage.clear();
+    handleReset();
+    setShowConfirmModal(false);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  /**
+   * Cancel the clear data action
+   * Why this matters: Allows users to back out of the destructive action
+   */
+  const cancelClearData = () => {
+    setShowConfirmModal(false);
+  };
+
   return (
     <div className="settings-page">
       {/* Settings Header */}
       <div className="settings-header">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-6">
           <Settings style={{width: '2rem', height: '2rem'}} />
           <h1 className="page-title">Settings</h1>
         </div>
@@ -214,13 +243,7 @@ const SettingsPage: React.FC = () => {
                 <span className="setting-description">Remove all stored analyses and settings</span>
               </label>
               <button
-                onClick={() => {
-                  if (window.confirm('Are you sure you want to clear all data? This cannot be undone.')) {
-                    localStorage.clear();
-                    handleReset();
-                    window.alert('All data cleared successfully.');
-                  }
-                }}
+                onClick={showClearConfirmation}
                 className="setting-danger-btn"
               >
                 Clear All Data
@@ -229,6 +252,37 @@ const SettingsPage: React.FC = () => {
           </div>
         </div>
       </div>
+
+      {/* Confirmation Modal */}
+      {showConfirmModal && (
+        <div className={`confirmation-modal-backdrop ${showConfirmModal ? 'open' : ''}`}>
+          <div className={`confirmation-modal ${showConfirmModal ? 'open' : ''}`}>
+            <div className="confirmation-modal-header">
+              <div className="confirmation-modal-icon">
+                <AlertTriangle style={{width: '1.5rem', height: '1.5rem'}} />
+              </div>
+              <h3 className="confirmation-modal-title">Clear All Data?</h3>
+              <p className="confirmation-modal-message">
+                This action cannot be undone and will permanently delete all your saved analyses, settings, and preferences.
+              </p>
+            </div>
+            <div className="confirmation-modal-actions">
+              <button
+                onClick={cancelClearData}
+                className="confirmation-modal-btn confirmation-modal-btn-cancel"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmClearData}
+                className="confirmation-modal-btn confirmation-modal-btn-confirm"
+              >
+                Delete All
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Fix UI Consistency and Navigation in History and Settings Pages

### Description
This PR improves user experience by enhancing navigation flow, standardizing UI components, and creating visual consistency across the History and Settings pages, along with refinements to the DigDeeperModal component.

### Changes Made
- **History Page**: Updated "Run Your First Analysis" link to navigate directly to `/app` instead of `/` for better user flow
- **Settings Page**: Replaced browser's `window.confirm` popup with custom modal that matches the design system used in History page
- **DigDeeperModal**: Repositioned "Join conversation on Reddit" button to appear after conversation stage labels but before "Resumed" indicator
- **Button Styling**: Standardized button sizing and border radius (`0.25rem`) to match other badges in the metadata section
- **Modal Consistency**: Applied consistent modal styling patterns across both History and Settings pages

### Benefits
- **Improved Navigation**: Users clicking "Run Your First Analysis" now go directly to the analysis interface
- **Design Consistency**: Custom modals provide a cohesive experience instead of jarring browser popups
- **Better Visual Hierarchy**: Reddit button placement creates logical information flow in conversation interface
- **Professional UX**: Consistent styling patterns reinforce brand identity and improve user confidence
- **Accessibility**: Custom modals are more accessible than browser-native popups

### Testing
- Verified History page "Run Your First Analysis" link navigates to correct `/app` route
- Confirmed Settings page "Clear All Data" triggers custom modal instead of browser popup
- Tested modal styling consistency between History and Settings pages
- Validated DigDeeperModal button positioning and sizing matches other metadata elements
- Checked responsive behavior across different screen sizes