### PR TITLE
fix: correct API URL fallbacks to use port 3003 instead of 3001

### DIFF
--- a/src/pages/AppPage.tsx
+++ b/src/pages/AppPage.tsx
@@ -5,7 +5,7 @@ import { WorkflowResponse } from '../types';
 
 const AppPage: React.FC = () => {
   const [currentResults, setCurrentResults] = useState<WorkflowResponse | null>(null);
-  const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:3001';
+  const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:3003';
 
   /**
    * Load saved results from localStorage on component mount

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -15,7 +15,7 @@ const SettingsPage: React.FC = () => {
     theme: 'light',
     autoSave: true,
     defaultLimit: 5,
-    apiUrl: process.env.REACT_APP_API_URL || 'http://localhost:3001',
+    apiUrl: process.env.REACT_APP_API_URL || 'http://localhost:3003',
     notifications: true,
     autoRefresh: false
   });
@@ -50,7 +50,7 @@ const SettingsPage: React.FC = () => {
       theme: 'light',
       autoSave: true,
       defaultLimit: 5,
-      apiUrl: process.env.REACT_APP_API_URL || 'http://localhost:3001',
+      apiUrl: process.env.REACT_APP_API_URL || 'http://localhost:3003',
       notifications: true,
       autoRefresh: false
     };


### PR DESCRIPTION
## Fix API URL Fallback Configurations

### Description
This PR corrects inconsistent API URL fallbacks in the frontend application. The fallback URLs were incorrectly pointing to port 3001 instead of the proper backend port 3003, which could cause connection issues when environment variables are not set.

### Changes Made
- Updated `AppPage.tsx` API URL fallback from `localhost:3001` to `localhost:3003`
- Updated `SettingsPage.tsx` default API URL configurations to use `localhost:3003`
- Ensured consistency across all components that reference the backend API
- Maintained environment variable precedence while fixing fallback values

### Benefits
- Resolves potential connection issues when REACT_APP_API_URL is not set
- Ensures consistent backend port references across the entire frontend application
- Improves development experience by using correct default values
- Prevents silent failures when environment configuration is missing

### Testing
- Verified fallback URLs now correctly point to backend port 3003
- Confirmed environment variable precedence is maintained
- Tested both development scenarios (with and without .env configuration)
- No breaking changes to existing functionality or user experience