### PR TITLE
fix: adjust content creation modal panel widths to 40/60 split

### DIFF
--- a/src/components/ContentCreationModal.tsx
+++ b/src/components/ContentCreationModal.tsx
@@ -1992,7 +1992,6 @@ Return ONLY the JSON object, no additional text.`;
           <div className="content-modal-layout" style={{ flex: 1, overflow: 'hidden', display: 'flex' }}>
             {/* Left Panel - Prompts */}
             <div className="content-modal-panel" style={{ 
-              flex: 1, 
               padding: '1.5rem', 
               overflowY: 'auto',
               borderRight: '0.0625rem solid #e5e7eb'
@@ -2215,12 +2214,11 @@ Return ONLY the JSON object, no additional text.`;
             {/* Right Panel - Generated Content */}
             <div ref={rightPanelRef} className="content-modal-panel" style={{ 
               position: 'relative',
-              flex: 1,
               padding: '1.5rem',
               overflowY: 'auto'
             }}>
               <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', marginBottom: '1.5rem' }}>
-                <h3 style={{ fontSize: '1.125rem', fontWeight: '600', color: '#374151', margin: 0, marginBottom: '1rem' }}>Generated Content</h3>
+                <h3 className="mobile-only-heading" style={{ fontSize: '1.125rem', fontWeight: '600', color: '#374151', margin: 0, marginBottom: '1rem' }}>Generated Content</h3>
                 
                 {/* Clear Button - Centered */}
                 {generatedContent && (

--- a/src/index.css
+++ b/src/index.css
@@ -2780,12 +2780,20 @@ footer {
   display: block;
 }
 
+.mobile-only-heading {
+  display: block;
+}
+
 .desktop-only {
   display: none;
 }
 
 @media (min-width: 48.0625rem) {
   .mobile-only {
+    display: none;
+  }
+  
+  .mobile-only-heading {
     display: none;
   }
   


### PR DESCRIPTION
## Fix Content Creation Modal Panel Layout

### Description
This PR adjusts the width distribution of panels in the Content Creation Modal to improve content visibility and user experience. The left panel (Content Generation Prompts) is reduced to 40% width while the right panel (Generated Content) is expanded to 60% width, providing more space for the generated content which typically requires more real estate.

### Changes Made
- Removed inline `flex: 1` styles from both left and right panels that were overriding CSS classes
- Ensured CSS classes properly control panel widths with 40/60 split
- Maintained responsive behavior and scrolling functionality
- Removed redundant "Generated Content" heading on desktop view

### Benefits
- Better use of screen real estate with content-appropriate width distribution
- Improved readability of generated content with more horizontal space
- Cleaner desktop interface by removing redundant heading
- Maintained mobile-first responsive design

### Testing
- Verified panel width distribution on desktop screens
- Confirmed responsive behavior on different screen sizes
- Checked that scrolling functionality works correctly in both panels
- Validated that mobile view remains unchanged