### PR TITLE
feat: hide Landing Page Analyzer via feature flag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,7 +114,7 @@ const AppLayout: React.FC = () => {
           <Routes>
             <Route path="/app" element={<AppPage />} />
             {FEATURE_FLAGS.showCRO && <Route path="/cro" element={<CROPage />} />}
-            <Route path="/landing-page-analyzer" element={<LandingPageAnalyzer />} />
+            {FEATURE_FLAGS.showLandingPageAnalyzer && <Route path="/landing-page-analyzer" element={<LandingPageAnalyzer />} />}
             <Route path="/gong-analysis" element={<GongAnalysisPage />} />
             <Route path="/playbooks-creator" element={<PlaybooksPage />} />
             <Route path="/blog-creator" element={<BlogCreatorPage />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -60,14 +60,16 @@ const Navigation: React.FC<NavigationProps> = ({ onItemClick }) => {
             Gong Call Analyzer
           </NavLink>
           
-          <NavLink 
-            to="/landing-page-analyzer" 
-            className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}
-            onClick={onItemClick}
-          >
-            <Monitor className="nav-icon" />
-            Landing Page CRO Analyzer
-          </NavLink>
+          {FEATURE_FLAGS.showLandingPageAnalyzer && (
+            <NavLink 
+              to="/landing-page-analyzer" 
+              className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}
+              onClick={onItemClick}
+            >
+              <Monitor className="nav-icon" />
+              Landing Page CRO Analyzer
+            </NavLink>
+          )}
           
           <NavLink 
             to="/brand-kit" 

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -12,7 +12,7 @@ export interface FeatureFlags {
 export const FEATURE_FLAGS: FeatureFlags = {
   showCRO: false, // Hide CRO for production
   showGongAnalysis: true,
-  showLandingPageAnalyzer: true,
+  showLandingPageAnalyzer: false, // Hide Landing Page Analyzer from navigation
   showBlogCreator: true,
   showPlaybooksCreator: true,
   showBrandKit: true,


### PR DESCRIPTION
## 🎯 Hide Landing Page Analyzer via Feature Flag

### Summary
Implemented feature flag control to completely hide the Landing Page Analyzer from the application UI. This allows for easy toggling of the feature without code changes.

### Changes Made
- **Feature Flag**: Set `showLandingPageAnalyzer` to `false` in feature flags configuration
- **Navigation**: Added conditional rendering to hide Landing Page Analyzer menu item
- **Routing**: Added conditional rendering to hide Landing Page Analyzer route
- **Complete UI Hide**: Feature is now completely hidden from both navigation and routing

### Technical Details
- Modified `src/utils/featureFlags.ts` to set flag to false
- Updated `src/components/Navigation.tsx` with conditional NavLink rendering
- Updated `src/App.tsx` with conditional Route rendering
- Follows existing pattern used for CRO feature flag

### Testing
- [x] Landing Page Analyzer no longer appears in left navigation
- [x] Direct URL access to `/landing-page-analyzer` returns 404
- [x] Feature can be re-enabled by changing flag to `true`

### Impact
- **Users**: Landing Page Analyzer feature is completely hidden
- **Developers**: Easy toggle via feature flag for future re-enablement
- **No Breaking Changes**: All other features remain functional