### PR TITLE
Fix CORS errors for Netlify deployment

### DIFF
--- a/src/pages/CTACreatorPage.tsx
+++ b/src/pages/CTACreatorPage.tsx
@@ -246,7 +246,7 @@ const CTACreatorPage: React.FC = () => {
         console.error('Error loading VoC Kit data:', error);
       }
 
-      let endpoint = 'http://localhost:3003/api/cta-generation/generate-from-url';
+      let endpoint = `${process.env.NODE_ENV === 'production' ? 'https://apollo-reddit-scraper-backend.vercel.app' : 'http://localhost:3003'}/api/cta-generation/generate-from-url`;
       let requestBody: any = { 
         url: articleUrl, 
         enhanced_analysis: enhancedAnalysis,
@@ -254,14 +254,14 @@ const CTACreatorPage: React.FC = () => {
       };
 
       if (inputMethod === 'text') {
-        endpoint = 'http://localhost:3003/api/cta-generation/generate-from-text';
+        endpoint = `${process.env.NODE_ENV === 'production' ? 'https://apollo-reddit-scraper-backend.vercel.app' : 'http://localhost:3003'}/api/cta-generation/generate-from-text`;
         requestBody = { 
           text: articleText, 
           enhanced_analysis: enhancedAnalysis,
           voc_kit_data: vocKitData
         };
       } else if (inputMethod === 'markdown') {
-        endpoint = 'http://localhost:3003/api/cta-generation/generate-from-markdown';
+        endpoint = `${process.env.NODE_ENV === 'production' ? 'https://apollo-reddit-scraper-backend.vercel.app' : 'http://localhost:3003'}/api/cta-generation/generate-from-markdown`;
         requestBody = { 
           markdown: articleMarkdown, 
           enhanced_analysis: enhancedAnalysis,

--- a/src/pages/VoCKitPage.tsx
+++ b/src/pages/VoCKitPage.tsx
@@ -132,7 +132,7 @@ const VoCKitPage: React.FC = () => {
     const jobId = localStorage.getItem('apollo_voc_analysis_job_id');
     if (jobId) {
       try {
-        const response = await fetch(`http://localhost:3003/api/voc-extraction/job-status/${jobId}`);
+        const response = await fetch(`${process.env.NODE_ENV === 'production' ? 'https://apollo-reddit-scraper-backend.vercel.app' : 'http://localhost:3003'}/api/voc-extraction/job-status/${jobId}`);
         const result = await response.json();
         
         if (result.success) {
@@ -166,7 +166,7 @@ const VoCKitPage: React.FC = () => {
   const startPolling = (jobId: string) => {
     const interval = setInterval(async () => {
       try {
-        const response = await fetch(`http://localhost:3003/api/voc-extraction/job-status/${jobId}`);
+        const response = await fetch(`${process.env.NODE_ENV === 'production' ? 'https://apollo-reddit-scraper-backend.vercel.app' : 'http://localhost:3003'}/api/voc-extraction/job-status/${jobId}`);
         const result = await response.json();
         
         if (result.success && result.status === 'completed' && result.data) {
@@ -279,7 +279,7 @@ const VoCKitPage: React.FC = () => {
     
     try {
       // Start async analysis job
-      const response = await fetch('http://localhost:3003/api/voc-extraction/start-analysis', {
+      const response = await fetch(`${process.env.NODE_ENV === 'production' ? 'https://apollo-reddit-scraper-backend.vercel.app' : 'http://localhost:3003'}/api/voc-extraction/start-analysis`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION

### Root Cause
Several frontend components were using hardcoded `localhost:3003` URLs instead of environment-based URLs, causing production deployments to try connecting to localhost (which doesn't exist in production).

### Solution
✅ **VoCKitPage.tsx**: Updated 3 hardcoded localhost URLs to use environment-based URLs:
- `extractPainPoints()` function 
- `checkOngoingAnalysis()` function
- `startPolling()` function

✅ **CTACreatorPage.tsx**: Updated 3 hardcoded localhost URLs for CTA generation endpoints:
- generate-from-url endpoint
- generate-from-text endpoint  
- generate-from-markdown endpoint

### Implementation Details
Replaced hardcoded URLs with:
```javascript
${process.env.NODE_ENV === 'production' ? 'https://apollo-reddit-scraper-backend.vercel.app' : 'http://localhost:3003'}
```

This pattern:
- Uses `localhost:3003` for local development
- Uses production backend URL for deployed apps
- Matches existing patterns used throughout the codebase

### Testing
- [x] Local development still works with localhost:3003
- [x] Production deployment connects to correct backend URL
- [x] VoC Kit analysis functions properly on Netlify
- [x] CTA generation works properly on Netlify

### Impact
🎯 **Fixes Netlify CORS errors**  
🎯 **Enables VoC Kit functionality in production**  
🎯 **Enables CTA generation functionality in production**  
🎯 **Maintains local development workflow**