### PR TITLE
feat: remove pain points count from VoC insights UI

### DIFF
--- a/src/components/BlogContentActionModal.tsx
+++ b/src/components/BlogContentActionModal.tsx
@@ -3606,28 +3606,22 @@ Return ONLY the JSON object with the three required fields. No additional text o
                             </div>
                             
                             <div style={{ fontSize: '0.625rem', color: '#374151' }}>
-                              <div>📊 Pain Points: {
-                                generatedCTAs.position_specific_context?.[position as keyof typeof generatedCTAs.position_specific_context]?.pain_points?.length || 
-                                generatedCTAs.pain_point_context?.primary_pain_points?.length || 0
-                              }</div>
-                              <div style={{ marginTop: '0.25rem' }}>
-                                <div style={{ fontWeight: '600', marginBottom: '0.25rem' }}>💬 Customer Language Used:</div>
-                                {(generatedCTAs.position_specific_context?.[position as keyof typeof generatedCTAs.position_specific_context]?.customer_quotes || 
-                                  generatedCTAs.pain_point_context?.customer_quotes_used || [])?.map((quote: string, idx: number) => (
-                                  <div key={idx} style={{
-                                    fontSize: '0.6875rem',
-                                    fontStyle: 'italic',
-                                    color: '#059669',
-                                    backgroundColor: '#ecfdf5',
-                                    padding: '0.25rem 0.5rem',
-                                    borderRadius: '0.25rem',
-                                    marginBottom: '0.25rem',
-                                    border: '1px solid #bbf7d0'
-                                  }}>
-                                    "{quote}"
-                                  </div>
-                                ))}
-                              </div>
+                              <div style={{ fontWeight: '600', marginBottom: '0.25rem' }}>💬 Customer Language Used:</div>
+                              {(generatedCTAs.position_specific_context?.[position as keyof typeof generatedCTAs.position_specific_context]?.customer_quotes || 
+                                generatedCTAs.pain_point_context?.customer_quotes_used || [])?.map((quote: string, idx: number) => (
+                                <div key={idx} style={{
+                                  fontSize: '0.6875rem',
+                                  fontStyle: 'italic',
+                                  color: '#059669',
+                                  backgroundColor: '#ecfdf5',
+                                  padding: '0.25rem 0.5rem',
+                                  borderRadius: '0.25rem',
+                                  marginBottom: '0.25rem',
+                                  border: '1px solid #bbf7d0'
+                                }}>
+                                  "{quote}"
+                                </div>
+                              ))}
                             </div>
                           </div>
                         )}

--- a/src/pages/CTACreatorPage.tsx
+++ b/src/pages/CTACreatorPage.tsx
@@ -1605,28 +1605,22 @@ Paste your markdown content here...
                         </div>
 
                         <div style={{ fontSize: '0.625rem', color: '#374151' }}>
-                          <div>📊 Pain Points: {
-                            generatedCTAs.position_specific_context?.[position as keyof typeof generatedCTAs.position_specific_context]?.pain_points?.length ||
-                            generatedCTAs.pain_point_context?.primary_pain_points?.length || 0
-                          }</div>
-                          <div style={{ marginTop: '0.25rem' }}>
-                            <div style={{ fontWeight: '600', marginBottom: '0.25rem' }}>💬 Customer Language Used:</div>
-                            {(generatedCTAs.position_specific_context?.[position as keyof typeof generatedCTAs.position_specific_context]?.customer_quotes ||
-                              generatedCTAs.pain_point_context?.customer_quotes_used || [])?.map((quote: string, idx: number) => (
-                              <div key={idx} style={{
-                                fontSize: '0.6875rem',
-                                fontStyle: 'italic',
-                                color: '#059669',
-                                backgroundColor: '#ecfdf5',
-                                padding: '0.25rem 0.5rem',
-                                borderRadius: '0.25rem',
-                                marginBottom: '0.25rem',
-                                border: '1px solid #bbf7d0'
-                              }}>
-                                "{quote}"
-                              </div>
-                            ))}
-                          </div>
+                          <div style={{ fontWeight: '600', marginBottom: '0.25rem' }}>💬 Customer Language Used:</div>
+                          {(generatedCTAs.position_specific_context?.[position as keyof typeof generatedCTAs.position_specific_context]?.customer_quotes ||
+                            generatedCTAs.pain_point_context?.customer_quotes_used || [])?.map((quote: string, idx: number) => (
+                            <div key={idx} style={{
+                              fontSize: '0.6875rem',
+                              fontStyle: 'italic',
+                              color: '#059669',
+                              backgroundColor: '#ecfdf5',
+                              padding: '0.25rem 0.5rem',
+                              borderRadius: '0.25rem',
+                              marginBottom: '0.25rem',
+                              border: '1px solid #bbf7d0'
+                            }}>
+                              "{quote}"
+                            </div>
+                          ))}
                         </div>
                       </div>
                     )}


### PR DESCRIPTION
## Remove Pain Points Count from VoC Insights UI

### Description
This PR simplifies the VoC insights display in both CTA generation interfaces by removing the redundant pain points count line, creating a cleaner and more focused user experience.

### Changes Made

#### **1. CTACreatorPage.tsx**
- **Removed pain points count display**: Eliminated the "📊 Pain Points: X" line from VoC insights section
- **Simplified layout structure**: Streamlined the display to focus directly on customer language
- **Improved visual hierarchy**: Reduced clutter by removing redundant numerical information

#### **2. BlogContentActionModal.tsx**
- **Removed pain points count display**: Eliminated the "📊 Pain Points: X" line to match CTACreatorPage
- **Consistent UI patterns**: Ensured both CTA interfaces have identical VoC insights display
- **Cleaner information architecture**: Focused user attention on what matters most - the customer quotes

### Before vs After

**Before:**
🎯 VoC Insights Used in This Beginning CTA
📊 Pain Points: 3
💬 Customer Language Used:
"Before Apollo, we were spending 4 hours a day just finding contact info"
"Manual prospecting took our entire morning"

**After:**
🎯 VoC Insights Used in This Beginning CTA
💬 Customer Language Used:
"Before Apollo, we were spending 4 hours a day just finding contact info"
"Manual prospecting took our entire morning"

### Benefits

#### **Enhanced User Experience**
- **Reduced cognitive load**: Users no longer need to process redundant numerical information
- **Improved focus**: Attention is directed to the actual customer language being used
- **Cleaner interface**: Less visual clutter creates a more professional appearance
- **Better readability**: Streamlined layout makes customer quotes more prominent

#### **Consistent Design**
- **Unified experience**: Both CTA generation interfaces now have identical VoC insights display
- **Design consistency**: Maintains the same visual patterns across components
- **Simplified maintenance**: Fewer UI elements to maintain and style

#### **Better Information Hierarchy**
- **Focused messaging**: Customer quotes are the primary information, not counts
- **Reduced redundancy**: Pain points count added no actionable value for users
- **Improved scannability**: Users can quickly see the relevant customer language

### Technical Details
- **No functional changes**: Only removed visual display elements, no logic changes
- **Maintained data structure**: All underlying pain point data remains available
- **Preserved styling**: Kept existing design tokens and visual patterns
- **Cross-component consistency**: Applied identical changes to both interfaces

### Testing
- ✅ Verified VoC insights section displays correctly without pain points count
- ✅ Confirmed customer quotes still render properly with correct styling
- ✅ Tested both CTACreatorPage and BlogContentActionModal interfaces
- ✅ Validated position-specific context still works (Beginning/Middle/Ending)
- ✅ Ensured no breaking changes to existing functionality

### Files Changed
- `frontend/src/pages/CTACreatorPage.tsx`: Removed pain points count from VoC insights
- `frontend/src/components/BlogContentActionModal.tsx`: Removed pain points count from VoC insights

**Result**: Both CTA generation interfaces now provide a cleaner, more focused VoC insights experience that highlights customer language without unnecessary numerical clutter. 🎯