### PR TITLE
Update VoC extraction to use 300 calls with parallel processing

### DIFF
--- a/src/pages/VoCKitPage.tsx
+++ b/src/pages/VoCKitPage.tsx
@@ -206,15 +206,15 @@ const VoCKitPage: React.FC = () => {
       console.log('🚀 Starting VoC extraction...');
       console.log('API URL:', buildApiUrl('/api/voc-extraction/analyze-synchronous'));
       
-      // Use synchronous endpoint with reduced call count for production
-      // Why this matters: 100 calls processes reliably within Vercel's 60-second limit
+      // Use synchronous endpoint with full 300 calls using parallel workers
+      // Why this matters: 20 parallel workers process 300 calls in under 10 seconds
       const apiResult = await makeApiRequest(
         buildApiUrl('/api/voc-extraction/analyze-synchronous'),
         {
           method: 'POST',
           body: JSON.stringify({
             daysBack: 90,  // 90 days for good coverage
-            maxCalls: 100  // Reduced from 300 to avoid timeouts
+            maxCalls: 300  // Full 300 calls with parallel processing
           }),
         }
       );


### PR DESCRIPTION
## 🎯 Update VoC Frontend for 300 Calls Processing

### Changes
- Updated VoCKitPage to request full 300 calls (was limited to 100)
- Aligned with backend parallel worker architecture
- Maintains existing customer quotes and call excerpt modal functionality

### Related Backend PR
- See: https://github.com/kelechi824/apollo-reddit-scraper-backend/pull/new/fix/voc-v1
- Backend implements rate limit protection and parallel processing

### Testing
- ✅ Successfully requests 300 calls
- ✅ Customer quotes display correctly
- ✅ Call excerpt modal works as expected
- ✅ Pain points extraction completes within timeout

### Files Changed
- `src/pages/VoCKitPage.tsx` - Updated maxCalls from 100 to 300