### PR TITLE
fix: standardize estimated time to 60 seconds for all post limits

### DIFF
--- a/src/components/AnalysisInterface.tsx
+++ b/src/components/AnalysisInterface.tsx
@@ -473,7 +473,7 @@ const AnalysisInterface: React.FC<AnalysisInterfaceProps> = ({ apiUrl, onAnalysi
             {/* Estimated Time Display - to the right of button */}
             <div className="time-estimate-right-of-button">
               <p>
-                Est. time: {limit === 3 ? '15-20 seconds' : limit === 5 ? '20-30 seconds' : '30-60 seconds'}
+                Est. time: 60 seconds
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Fix: Standardize Estimated Time to 60 Seconds for All Post Limits

### Description
This PR standardizes the estimated analysis time display to show a consistent "60 seconds" regardless of the number of posts selected in the dropdown. Previously, the interface showed different time estimates based on post count (15-20s for 3 posts, 20-30s for 5 posts, 30-60s for 10 posts).

### Changes Made
- Updated AnalysisInterface.tsx to display fixed "Est. time: 60 seconds" message
- Removed conditional logic that calculated different time estimates based on post limit
- Simplified the time estimation display for better user experience consistency

### Benefits
- Provides consistent user expectations regardless of post selection
- Sets conservative time expectations that won't disappoint users
- Simplifies the UI by removing dynamic calculations
- Reduces cognitive load for users who don't need to consider different timing scenarios

### Testing
- Verified the estimated time displays as "60 seconds" for all post limit options (3, 5, and 10 posts)
- Confirmed the change doesn't affect any other functionality in the analysis interface
- Tested that the display remains consistent across different browser states